### PR TITLE
Fix reading attributes on load, not on click

### DIFF
--- a/angular-stripe-checkout.js
+++ b/angular-stripe-checkout.js
@@ -53,12 +53,13 @@ function StripeCheckoutDirective($parse, StripeCheckout) {
   function link(scope, el, attrs) {
     var handler;
 
-    StripeCheckout.load()
-      .then(function() {
-        handler = StripeCheckout.configure(getOptions(el));
-      });
+    StripeCheckout.load();
+      // .then(function() {
+      //   handler = StripeCheckout.configure(getOptions(el));
+      // });
 
     el.on("click",function() {
+      handler = StripeCheckout.configure(getOptions(el));
       if (handler)
         handler.open(getOptions(el)).then(function(result) {
           var callback = $parse(attrs.stripeCheckout)(scope);


### PR DESCRIPTION
Since my key is supplied by the angular controller, sometimes it was not present at the time of load and so would get set to '[[siteAccount.publishableKey}}' instead of the actual key.

I moved the reading of the attribute options to after the click.